### PR TITLE
Improve `run.sh`

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -1,8 +1,8 @@
-#!/bin/bash
+#!/usr/bin/env sh
 
 while true
 do
-    $1 -m poetry run python -m mcodingbot
+    "${1:-python}" -m poetry run python -m mcodingbot
 
     echo "Hit CTRL+C to stop..."
     sleep 5


### PR DESCRIPTION
- Default to using `python` as executable if none is provided as the first argument
- Switch to using `/usr/bin/env sh` instead of `/bin/bash` since bashisms are not used
- Add newline at EOF (heathens!)