### PR TITLE
Update crescent to 0.2.4

### DIFF
--- a/mcodingbot/bot.py
+++ b/mcodingbot/bot.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import asyncio
 from typing import Any
 
 import aiohttp

--- a/mcodingbot/bot.py
+++ b/mcodingbot/bot.py
@@ -7,15 +7,14 @@ import aiohttp
 import crescent
 
 from mcodingbot.config import CONFIG
-from mcodingbot.tasks.stats import loop_update_channels
 
 
 class Bot(crescent.Bot):
     def __init__(self) -> None:
         super().__init__(token=CONFIG.discord_token)
 
-        self.plugins.load("mcodingbot.plugins.info")
-        self.plugins.load("mcodingbot.plugins.reactions")
+        self.plugins.load_folder("mcodingbot.plugins")
+        self.plugins.load_folder("mcodingbot.tasks")
 
         self._session: aiohttp.ClientSession | None = None
 
@@ -28,8 +27,6 @@ class Bot(crescent.Bot):
     async def start(self, *args: Any, **kwargs: Any) -> None:
         self._session = aiohttp.ClientSession()
         await super().start(*args, **kwargs)
-
-        asyncio.create_task(loop_update_channels(self))
 
     async def join(self, *args: Any, **kwargs: Any) -> None:
         await super().join(*args, **kwargs)

--- a/mcodingbot/plugins/info.py
+++ b/mcodingbot/plugins/info.py
@@ -2,8 +2,9 @@ import crescent
 import hikari
 
 from mcodingbot.config import CONFIG
+from mcodingbot.utils import Plugin
 
-plugin = crescent.Plugin()
+plugin = Plugin()
 
 
 @plugin.include

--- a/mcodingbot/plugins/info.py
+++ b/mcodingbot/plugins/info.py
@@ -3,7 +3,7 @@ import hikari
 
 from mcodingbot.config import CONFIG
 
-plugin = crescent.Plugin("basic")
+plugin = crescent.Plugin()
 
 
 @plugin.include

--- a/mcodingbot/plugins/reactions.py
+++ b/mcodingbot/plugins/reactions.py
@@ -3,9 +3,11 @@ import re
 import crescent
 import hikari
 
+from mcodingbot.utils import Plugin
+
 RUST_REGEX = re.compile(r"\brust\b", flags=re.I)
 
-plugin = crescent.Plugin()
+plugin = Plugin()
 
 
 @plugin.include

--- a/mcodingbot/plugins/reactions.py
+++ b/mcodingbot/plugins/reactions.py
@@ -5,7 +5,7 @@ import hikari
 
 RUST_REGEX = re.compile(r"\brust\b", flags=re.I)
 
-plugin = crescent.Plugin("reactions")
+plugin = crescent.Plugin()
 
 
 @plugin.include

--- a/mcodingbot/tasks/stats.py
+++ b/mcodingbot/tasks/stats.py
@@ -6,7 +6,10 @@ from dataclasses import dataclass
 from math import log
 from typing import TYPE_CHECKING, Any
 
+from crescent.ext import tasks
+
 from mcodingbot.config import CONFIG
+from mcodingbot.utils import Plugin
 
 if TYPE_CHECKING:
     from mcodingbot.bot import Bot
@@ -15,14 +18,16 @@ if TYPE_CHECKING:
 LOGGER = logging.getLogger(__file__)
 
 
-async def loop_update_channels(bot: Bot) -> None:
-    while True:
-        try:
-            await update_channels(bot)
-        except Exception:
-            LOGGER.error("Failed to update channel stats:", exc_info=True)
+plugin = Plugin()
 
-        await asyncio.sleep(5 * 60)
+
+@plugin.include
+@tasks.loop(minutes=5)
+async def loop() -> None:
+    try:
+        await update_channels(plugin.app)
+    except Exception:
+        LOGGER.error("Failed to update channel stats:", exc_info=True)
 
 
 async def update_channels(bot: Bot) -> None:

--- a/mcodingbot/tasks/stats.py
+++ b/mcodingbot/tasks/stats.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import asyncio
 import logging
 from dataclasses import dataclass
 from math import log

--- a/mcodingbot/utils/__init__.py
+++ b/mcodingbot/utils/__init__.py
@@ -1,5 +1,5 @@
 import typing
 
-from .plugin import *
+from .plugin import Plugin
 
 __all__: typing.Sequence[str] = ("Plugin",)

--- a/mcodingbot/utils/__init__.py
+++ b/mcodingbot/utils/__init__.py
@@ -1,0 +1,6 @@
+import typing
+
+from .plugin import *
+
+
+__all__: typing.Sequence[str] = ("Plugin",)

--- a/mcodingbot/utils/__init__.py
+++ b/mcodingbot/utils/__init__.py
@@ -1,5 +1,5 @@
 import typing
 
-from .plugin import Plugin
+from mcodingbot.utils.plugin import Plugin
 
 __all__: typing.Sequence[str] = ("Plugin",)

--- a/mcodingbot/utils/__init__.py
+++ b/mcodingbot/utils/__init__.py
@@ -2,5 +2,4 @@ import typing
 
 from .plugin import *
 
-
 __all__: typing.Sequence[str] = ("Plugin",)

--- a/mcodingbot/utils/plugin.py
+++ b/mcodingbot/utils/plugin.py
@@ -13,6 +13,4 @@ __all__: typing.Sequence[str] = ("Plugin",)
 class Plugin(crescent.Plugin):
     @property
     def app(self) -> Bot:
-        # NOTE: Worried that not using `if TYPE_CHECKING` for `Bot` will cause
-        # circular imports later down the line.
         return typing.cast("Bot", super().app)

--- a/mcodingbot/utils/plugin.py
+++ b/mcodingbot/utils/plugin.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 
-import crescent
 import typing
+
+import crescent
 
 if typing.TYPE_CHECKING:
     from mcodingbot.bot import Bot

--- a/mcodingbot/utils/plugin.py
+++ b/mcodingbot/utils/plugin.py
@@ -1,0 +1,13 @@
+import crescent
+import typing
+
+if typing.TYPE_CHECKING:
+    from mcodingbot.bot import Bot
+
+__all__: typing.Sequence[str] = ("Plugin",)
+
+
+class Plugin(crescent.Plugin):
+    @property
+    def app(self) -> Bot:
+        return typing.cast(Bot, super().app)

--- a/mcodingbot/utils/plugin.py
+++ b/mcodingbot/utils/plugin.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import crescent
 import typing
 
@@ -10,4 +12,6 @@ __all__: typing.Sequence[str] = ("Plugin",)
 class Plugin(crescent.Plugin):
     @property
     def app(self) -> Bot:
-        return typing.cast(Bot, super().app)
+        # NOTE: Worried that not using `if TYPE_CHECKING` for `Bot` will cause circular
+        # imports later down the line.
+        return typing.cast("Bot", super().app)

--- a/mcodingbot/utils/plugin.py
+++ b/mcodingbot/utils/plugin.py
@@ -13,6 +13,6 @@ __all__: typing.Sequence[str] = ("Plugin",)
 class Plugin(crescent.Plugin):
     @property
     def app(self) -> Bot:
-        # NOTE: Worried that not using `if TYPE_CHECKING` for `Bot` will cause circular
-        # imports later down the line.
+        # NOTE: Worried that not using `if TYPE_CHECKING` for `Bot` will cause
+        # circular imports later down the line.
         return typing.cast("Bot", super().app)

--- a/poetry.lock
+++ b/poetry.lock
@@ -141,7 +141,7 @@ python-dateutil = "*"
 
 [[package]]
 name = "distlib"
-version = "0.3.4"
+version = "0.3.5"
 description = "Distribution utilities"
 category = "dev"
 optional = false
@@ -200,7 +200,7 @@ speedups = ["aiodns (>=3.0,<4.0)", "cchardet (>=2.1,<3.0)", "Brotli (>=1.0,<2.0)
 
 [[package]]
 name = "hikari-crescent"
-version = "0.2.3"
+version = "0.2.4"
 description = "🌕 A command handler for Hikari that keeps your project neat and tidy."
 category = "main"
 optional = false
@@ -401,7 +401,7 @@ python-versions = ">=3.7"
 
 [[package]]
 name = "types-croniter"
-version = "1.3.0"
+version = "1.3.1"
 description = "Typing stubs for croniter"
 category = "main"
 optional = false
@@ -448,7 +448,7 @@ multidict = ">=4.0"
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.8,<3.11"
-content-hash = "cd40af3a776c83f2a4d7f19182556cbfc1b55a8043033f309ef9da7e21b07a5a"
+content-hash = "f34023a83358a5b5a85d3af00987e31c8bea55d0e8fcddbf1735c0f613279d8f"
 
 [metadata.files]
 aiohttp = []

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ license = "MIT"
 [tool.poetry.dependencies]
 python = "^3.8,<3.11"
 hikari = "^2.0.0-alpha.108"
-hikari-crescent = "^0.2.3"
+hikari-crescent = "^0.2.4"
 
 [tool.poetry.dev-dependencies]
 nox = "^2022.1.7"


### PR DESCRIPTION
This PR also makes updating youtube stuff into a crescent task. A new `Plugin` type is also added where `Plugin.app` is the mcoding bot type for type safety. All the plugins now use this type for consistency.
I also switched loading plugins to use `load_folder` because its a cleaner way to load plugins released in 0.2.4.
Plugin names are also removed because those are deprecated.