### PR TITLE
Minor improvements; changed stat format

### DIFF
--- a/mcodingbot/config.py
+++ b/mcodingbot/config.py
@@ -48,11 +48,11 @@ class Config:
         pth = Path("config.json")
 
         if not pth.exists():
-            c = Config()
+            c = cls()
         else:
             keys = set(inspect.signature(Config).parameters)
             with pth.open("r") as f:
-                c = Config(
+                c = cls(
                     **{
                         k: v
                         for k, v in cast(

--- a/mcodingbot/config.py
+++ b/mcodingbot/config.py
@@ -1,8 +1,10 @@
+from __future__ import annotations
+
 import inspect
 import json
 from dataclasses import asdict, dataclass
 from pathlib import Path
-from typing import Any, Dict, cast
+from typing import Any, cast
 
 _ALWAYS_SAVE = ["discord_token"]
 
@@ -30,7 +32,7 @@ class Config:
         pth = Path("config.json")
 
         dct = asdict(self)
-        tosave: Dict[str, Any] = {}
+        tosave: dict[str, Any] = {}
         defaults = type(self)()
         for k, v in dct.items():
             if k not in _ALWAYS_SAVE and getattr(defaults, k) == v:
@@ -42,7 +44,7 @@ class Config:
             f.write(json.dumps(tosave, indent=4))
 
     @classmethod
-    def load(cls) -> "Config":
+    def load(cls) -> Config:
         pth = Path("config.json")
 
         if not pth.exists():
@@ -54,7 +56,7 @@ class Config:
                     **{
                         k: v
                         for k, v in cast(
-                            "Dict[Any, Any]", json.loads(f.read())
+                            "dict[Any, Any]", json.load(f)
                         ).items()
                         if k in keys
                     }

--- a/mcodingbot/config.py
+++ b/mcodingbot/config.py
@@ -31,7 +31,7 @@ class Config:
 
         dct = asdict(self)
         tosave: Dict[str, Any] = {}
-        defaults = self.__class__()
+        defaults = type(self)()
         for k, v in dct.items():
             if k not in _ALWAYS_SAVE and getattr(defaults, k) == v:
                 continue

--- a/mcodingbot/config.py
+++ b/mcodingbot/config.py
@@ -41,7 +41,7 @@ class Config:
             tosave[k] = v
 
         with pth.open("w+") as f:
-            f.write(json.dumps(tosave, indent=4))
+            json.dump(tosave, f, indent=4)
 
     @classmethod
     def load(cls) -> Config:

--- a/mcodingbot/config.py
+++ b/mcodingbot/config.py
@@ -40,7 +40,7 @@ class Config:
 
             tosave[k] = v
 
-        with pth.open("w+") as f:
+        with pth.open("w") as f:
             json.dump(tosave, f, indent=4)
 
     @classmethod

--- a/mcodingbot/tasks/stats.py
+++ b/mcodingbot/tasks/stats.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import logging
 from dataclasses import dataclass
+from decimal import Decimal
 from math import log2
 from typing import TYPE_CHECKING, Any
 
@@ -121,6 +122,18 @@ async def get_stats(bot: Bot) -> Stats:
     return _last_known_stats
 
 
+def format_float(n: int | float) -> int | float:
+    if float(n).is_integer():
+        return int(n)
+    return n
+
+
+def floor(number: int | float, ndigits: int = 0) -> float:
+    n: int | float = 10 ** ndigits
+    return int(number * n) / n
+
+
+
 def display_stats(stat: int | float) -> str:
     if stat < 1_000:
         pretty_stat = stat
@@ -132,16 +145,10 @@ def display_stats(stat: int | float) -> str:
         pretty_stat = stat / 1_000_000
         unit = "M"
 
-    pretty_stat = int(pretty_stat * 100) / 100
-    exp_stat = int(log2(stat) * 10) / 10
+    pretty_stat = format_float(floor(pretty_stat, 2))
+    exp_stat = format_float(floor(log2(stat), 2))
     # ^ this might not be as accurate as the member count thing when
     # someone picky actually calculates it, but I suppose it's not
     # gonna be such a problem if it's gonna be shown as e.g. "44.3K"
-
-    if float(exp_stat).is_integer():
-        exp_stat = int(exp_stat)
-
-    if float(pretty_stat).is_integer():
-        pretty_stat = int(pretty_stat)
 
     return f"2**{exp_stat} ({pretty_stat}{unit})"

--- a/mcodingbot/tasks/stats.py
+++ b/mcodingbot/tasks/stats.py
@@ -121,7 +121,7 @@ async def get_stats(bot: Bot) -> Stats:
     return _last_known_stats
 
 
-def format_float(n: int | float) -> int | float:
+def strip_trailing_zeros(n: int | float) -> int | float:
     if float(n).is_integer():
         return int(n)
     return n
@@ -143,8 +143,8 @@ def display_stats(stat: int | float) -> str:
         pretty_stat = stat / 1_000_000
         unit = "M"
 
-    pretty_stat = format_float(truncate_decimals(pretty_stat, 2))
-    exp_stat = format_float(truncate_decimals(log2(stat), 2))
+    pretty_stat = strip_trailing_zeros(truncate_decimals(pretty_stat, 2))
+    exp_stat = strip_trailing_zeros(truncate_decimals(log2(stat), 2))
     # ^ this might not be as accurate as the member count thing when
     # someone picky actually calculates it, but I suppose it's not
     # gonna be such a problem if it's gonna be shown as e.g. "44.3K"

--- a/mcodingbot/tasks/stats.py
+++ b/mcodingbot/tasks/stats.py
@@ -122,14 +122,14 @@ async def get_stats(bot: Bot) -> Stats:
 
 
 def display_stats(stat: int | float) -> str:
-    if stat < 10**3:
+    if stat < 1_000:
         pretty_stat = stat
         unit = ""
-    elif stat < 10**6:
-        pretty_stat = stat / 10**3
+    elif stat < 1_000_000:
+        pretty_stat = stat / 1_000
         unit = "K"
     else:
-        pretty_stat = stat / 10**6
+        pretty_stat = stat / 1_000_000
         unit = "M"
 
     pretty_stat = round(pretty_stat, 2)

--- a/mcodingbot/tasks/stats.py
+++ b/mcodingbot/tasks/stats.py
@@ -127,7 +127,7 @@ def format_float(n: int | float) -> int | float:
     return n
 
 
-def floor(number: int | float, ndigits: int = 0) -> float:
+def truncate_decimals(number: int | float, ndigits: int = 0) -> float:
     n: int | float = 10**ndigits
     return int(number * n) / n
 
@@ -143,8 +143,8 @@ def display_stats(stat: int | float) -> str:
         pretty_stat = stat / 1_000_000
         unit = "M"
 
-    pretty_stat = format_float(floor(pretty_stat, 2))
-    exp_stat = format_float(floor(log2(stat), 2))
+    pretty_stat = format_float(truncate_decimals(pretty_stat, 2))
+    exp_stat = format_float(truncate_decimals(log2(stat), 2))
     # ^ this might not be as accurate as the member count thing when
     # someone picky actually calculates it, but I suppose it's not
     # gonna be such a problem if it's gonna be shown as e.g. "44.3K"

--- a/mcodingbot/tasks/stats.py
+++ b/mcodingbot/tasks/stats.py
@@ -128,9 +128,8 @@ def format_float(n: int | float) -> int | float:
 
 
 def floor(number: int | float, ndigits: int = 0) -> float:
-    n: int | float = 10 ** ndigits
+    n: int | float = 10**ndigits
     return int(number * n) / n
-
 
 
 def display_stats(stat: int | float) -> str:

--- a/mcodingbot/tasks/stats.py
+++ b/mcodingbot/tasks/stats.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import logging
 from dataclasses import dataclass
-from math import log
+from math import log2
 from typing import TYPE_CHECKING, Any
 
 from crescent.ext import tasks
@@ -133,7 +133,7 @@ def display_stats(stat: int | float) -> str:
         unit = "M"
 
     pretty_stat = round(pretty_stat, 2)
-    exp_stat = round(log(stat, 2), 1)
+    exp_stat = int(log2(stat) * 10) / 10
     # ^ this might not be as accurate as the member count thing when
     # someone picky actually calculates it, but I suppose it's not
     # gonna be such a problem if it's gonna be shown as e.g. "44.3K"

--- a/mcodingbot/tasks/stats.py
+++ b/mcodingbot/tasks/stats.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import logging
 from dataclasses import dataclass
-from decimal import Decimal
 from math import log2
 from typing import TYPE_CHECKING, Any
 

--- a/mcodingbot/tasks/stats.py
+++ b/mcodingbot/tasks/stats.py
@@ -46,7 +46,6 @@ async def update_channels(bot: Bot) -> None:
     else:
         LOGGER.warning("No view count channel to update stats for.")
 
-    # get the member count
     if not member_channel:
         return LOGGER.warning("No member count channel to update stats for.")
 

--- a/mcodingbot/tasks/stats.py
+++ b/mcodingbot/tasks/stats.py
@@ -132,7 +132,7 @@ def display_stats(stat: int | float) -> str:
         pretty_stat = stat / 1_000_000
         unit = "M"
 
-    pretty_stat = round(pretty_stat, 2)
+    pretty_stat = int(pretty_stat * 100) / 100
     exp_stat = int(log2(stat) * 10) / 10
     # ^ this might not be as accurate as the member count thing when
     # someone picky actually calculates it, but I suppose it's not

--- a/mcodingbot/utils/__init__.py
+++ b/mcodingbot/utils/__init__.py
@@ -1,5 +1,5 @@
-import typing
+from typing import Sequence
 
 from mcodingbot.utils.plugin import Plugin
 
-__all__: typing.Sequence[str] = ("Plugin",)
+__all__: Sequence[str] = ("Plugin",)

--- a/mcodingbot/utils/plugin.py
+++ b/mcodingbot/utils/plugin.py
@@ -1,16 +1,16 @@
 from __future__ import annotations
 
-import typing
+from typing import cast, Sequence, TYPE_CHECKING
 
 import crescent
 
-if typing.TYPE_CHECKING:
+if TYPE_CHECKING:
     from mcodingbot.bot import Bot
 
-__all__: typing.Sequence[str] = ("Plugin",)
+__all__: Sequence[str] = ("Plugin",)
 
 
 class Plugin(crescent.Plugin):
     @property
     def app(self) -> Bot:
-        return typing.cast("Bot", super().app)
+        return cast("Bot", super().app)

--- a/mcodingbot/utils/plugin.py
+++ b/mcodingbot/utils/plugin.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import cast, Sequence, TYPE_CHECKING
+from typing import TYPE_CHECKING, Sequence, cast
 
 import crescent
 


### PR DESCRIPTION
### Added
- Helper functions for `display_stats`

### Changed
- Made the `Config.load` class method actually use `cls` over `Config`
- Made `Config.save` use `type(self)` over `self.__class__`
- Made `typing` imports and typehints consistent
- Simplified `json.loads(f.read())` to `json.load(f)`
- Simplified `f.write(json.dumps(obj))` to `json.dump(obj, f)`
- Simplified `math.log(n, 2)` to `math.log2(n)`
- Changed exponents to literals in `display_stats`
- `display_stats`' exponents and approximate values will now be floored instead of rounded
  > Example for 1007:
  > `2**10 (1.01K)` -> `2**9.9 (1K)` (`2**10` would actually be displayed once 1024 is hit)
- `display_stats` will now display 2 decimal places instead of 1 for exponents
  > Example for 1000:
  > `2**10 (1K)` -> `2**9.96 (1K)`

### Removed
- Deleted a random comment that did not seem to fit anywhere (?)
