### PR TITLE
fix: use custom helper function instead of `round`

### DIFF
--- a/mcodingbot/plugins/info.py
+++ b/mcodingbot/plugins/info.py
@@ -7,11 +7,16 @@ from mcodingbot.utils import Context, Plugin
 plugin = Plugin()
 
 
+def nat_round(__x: int | float) -> int:
+    n = int(__x)
+    return n + (__x - n >= .5)
+
+
 @plugin.include
 @crescent.command(name="ping", description="Pong!")
 class PingCommand:
     async def callback(self, ctx: Context) -> None:
-        await ctx.respond(f"Pong! {int(ctx.app.heartbeat_latency * 1000)} ms.")
+        await ctx.respond(f"Pong! {nat_round(ctx.app.heartbeat_latency * 1000)} ms.")
 
 
 @plugin.include

--- a/mcodingbot/plugins/info.py
+++ b/mcodingbot/plugins/info.py
@@ -11,7 +11,7 @@ plugin = Plugin()
 @crescent.command(name="ping", description="Pong!")
 class PingCommand:
     async def callback(self, ctx: Context) -> None:
-        await ctx.respond(f"Pong! {round(ctx.app.heartbeat_latency*1000)} ms.")
+        await ctx.respond(f"Pong! {int(ctx.app.heartbeat_latency * 1000)} ms.")
 
 
 @plugin.include

--- a/mcodingbot/plugins/info.py
+++ b/mcodingbot/plugins/info.py
@@ -7,15 +7,22 @@ from mcodingbot.utils import Context, Plugin
 plugin = Plugin()
 
 
-def nat_round(__x: float) -> int:
-    n = int(__x)
-    return n + (__x - n >= 0.5)
+def natural_round(x: float) -> int:
+    """
+    Rounds in the same way as Python 2's `round()`.
+    If the real part of x is >= .5, rounds up ; else, rounds down.
+    """
+
+    n = int(x)
+    return n + (x - n >= 0.5)
 
 
 @plugin.include
 @crescent.command(name="ping", description="Pong!")
 async def ping(ctx: Context) -> None:
-    await ctx.respond(f"Pong! {nat_round(ctx.app.heartbeat_latency*1000)} ms.")
+    await ctx.respond(
+        f"Pong! {natural_round(ctx.app.heartbeat_latency*1000)} ms."
+    )
 
 
 @plugin.include

--- a/mcodingbot/plugins/info.py
+++ b/mcodingbot/plugins/info.py
@@ -7,7 +7,7 @@ from mcodingbot.utils import Context, Plugin
 plugin = Plugin()
 
 
-def nat_round(__x: int | float) -> int:
+def nat_round(__x: float) -> int:
     n = int(__x)
     return n + (__x - n >= 0.5)
 

--- a/mcodingbot/plugins/info.py
+++ b/mcodingbot/plugins/info.py
@@ -9,7 +9,7 @@ plugin = Plugin()
 
 def nat_round(__x: int | float) -> int:
     n = int(__x)
-    return n + (__x - n >= .5)
+    return n + (__x - n >= 0.5)
 
 
 @plugin.include


### PR DESCRIPTION
# Fix: use custom helper function instead of `round`

## Incipit

In Python 3.0, **`round()` built-in behavior changed** to follow industry standards by using [Banker's rounding algorithm](https://en.wikipedia.org/wiki/Rounding#Round_half_to_even) (which eliminates some mathematical bias), as stipulated by [this changelog](https://docs.python.org/3/whatsnew/3.0.html#:~:text=The%20round()%20function%20rounding%20strategy%20and%20return%20type%20have%20changed.).

## Consequences

This means that `round()` **rounds to the nearest even**, like the "Bankers" column in this table:
![image](https://user-images.githubusercontent.com/43090614/190468157-ffa25a4c-e4e2-491b-8e4f-edc5f0da468c.png)

Even though this is a great thing it happened, as it distributes proportionally the roundings and as [it also follows IEEE 754 as well](https://en.wikipedia.org/wiki/IEEE_754#Roundings_to_nearest), which is in favor of a global programming consistency, this rounding method is neither natural nor **expected in the context** it is currently applied in the code.

## Replacement candidate

`int()` built-in type could be a great candidate to replace `round()` ; however, it has one issue: **it always rounds down**, which is not natural rounding.

## Decision

Thus, my decision was to **write my own helper function**, which has to be simple and efficient.

Mimicking Python's own style, here's what I wrote:

```py
def natural_round(x: float) -> int:
    n = int(x)
    return n + (x - n >= .5)
```

Edited according to recent commits.

## Performance

I did not deeply benchmarked it, but on average, it's about **3 times slower than `int`** with large numbers (from `-1_000_000` to `1_000_000`, 1 million times).

Here's the [source code](https://pastebin.com/EmTKLVPU) of the benchmark script I've used.

On my machine, `int()` takes about `0.06` seconds whereas `nat_round()` takes about `0.19` seconds, which makes sense as this latter calls the first.

## Conclusion

I have therefore chosen to propose this PR, in order to fix this potentially unintended behavior.

Indeed:

- **`round()` is not really required** anyway, as we don't need/want specifically to round to a specific number of digits but **to the nearest integer**.
- `int()` does not fix the issue.
- `nat_round()` makes the rounding natural, as we would expect from data like latency.