### PR TITLE
Put stat names after the values

### DIFF
--- a/mcodingbot/plugins/stats.py
+++ b/mcodingbot/plugins/stats.py
@@ -37,12 +37,12 @@ async def update_channels(bot: Bot) -> None:
     member_channel = bot.cache.get_guild_channel(CONFIG.member_count_channel)
 
     if sub_channel:
-        await sub_channel.edit(name=f"Subs: {display_stats(stats.subs)}")
+        await sub_channel.edit(name=f"{display_stats(stats.subs)} subs")
     else:
         LOGGER.warning("No sub count channel to update stats for.")
 
     if view_channel:
-        await view_channel.edit(name=f"Views: {display_stats(stats.views)}")
+        await view_channel.edit(name=f"{display_stats(stats.views)} views")
     else:
         LOGGER.warning("No view count channel to update stats for.")
 
@@ -65,7 +65,7 @@ async def update_channels(bot: Bot) -> None:
     # never updated after the bot first starts.
     member_count = max(guild_approx_members, cached_members)
 
-    await member_channel.edit(name=f"Members: {display_stats(member_count)}")
+    await member_channel.edit(name=f"{display_stats(member_count)} members")
 
 
 @dataclass

--- a/mcodingbot/plugins/stats.py
+++ b/mcodingbot/plugins/stats.py
@@ -128,7 +128,7 @@ def strip_trailing_zeros(n: int | float) -> int | float:
 
 
 def truncate_decimals(number: int | float, ndigits: int = 0) -> float:
-    n: int | float = 10**ndigits
+    n: int | float = 10 ** ndigits
     return int(number * n) / n
 
 

--- a/mcodingbot/plugins/stats.py
+++ b/mcodingbot/plugins/stats.py
@@ -128,7 +128,7 @@ def strip_trailing_zeros(n: int | float) -> int | float:
 
 
 def truncate_decimals(number: int | float, ndigits: int = 0) -> float:
-    n: int | float = 10 ** ndigits
+    n: int | float = 10**ndigits
     return int(number * n) / n
 
 


### PR DESCRIPTION
Changes `Cakes: 2**4.68 (25)` to `2**4.68 (25) cakes` to avoid stuff like this:

<img width="225" alt="image" src="https://user-images.githubusercontent.com/77130613/193172410-49e5a854-4cbe-402a-bdb2-4b64d4a9a9ca.png">

It doesn't look the best, but I don't have a better idea 💀