### PR TITLE
gh-73: Add the main script to pyproject.toml

### DIFF
--- a/mcodingbot/__main__.py
+++ b/mcodingbot/__main__.py
@@ -1,7 +1,7 @@
 from mcodingbot.bot import Bot
 
 
-def main():
+def main() -> None:
     Bot().run()
 
 

--- a/mcodingbot/__main__.py
+++ b/mcodingbot/__main__.py
@@ -1,4 +1,9 @@
 from mcodingbot.bot import Bot
 
-if __name__ == "__main__":
+
+def main():
     Bot().run()
+
+
+if __name__ == "__main__":
+    main()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.black]
-line-length=79
-skip-magic-trailing-comma=true
+line-length = 79
+skip-magic-trailing-comma = true
 
 [tool.poetry]
 name = "mcodingbot"
@@ -8,6 +8,9 @@ version = "0.1.0"
 description = "The Discord bot for the mCoding Discord server."
 authors = ["Your Name <you@example.com>"]
 license = "MIT"
+
+[tool.poetry.scripts]
+mcodingbot = "mcodingbot.__main__:main"
 
 [tool.poetry.dependencies]
 python = "^3.8,<3.11"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ authors = ["Your Name <you@example.com>"]
 license = "MIT"
 
 [tool.poetry.scripts]
-mcodingbot = "mcodingbot.__main__:main"
+bot = "mcodingbot.__main__:main"
 
 [tool.poetry.dependencies]
 python = "^3.8,<3.11"


### PR DESCRIPTION
Closes issue #73

Typing the following line now directly runs the bot:

```
poetry run bot
```

For technical reasons, I had to move `mcodingbot/__main__.py` main code to a function, and I believe it's better as it is in this commit.