### PR TITLE
Highlight Cooldowns

### DIFF
--- a/mcodingbot/config.py
+++ b/mcodingbot/config.py
@@ -25,7 +25,7 @@ class Config:
     donor_role: int = -1
 
     # capacity, cooldown
-    message_sent_cooldown: tuple[float, float] = (1, 60)
+    highlight_message_sent_cooldown: tuple[float, float] = (1, 60)
     highlight_trigger_cooldown: tuple[float, float] = (1, 30)
 
     mcoding_yt_id: str = "YOUTUBE_CHANNEL_ID"

--- a/mcodingbot/config.py
+++ b/mcodingbot/config.py
@@ -24,6 +24,9 @@ class Config:
     patron_role: int = -1
     donor_role: int = -1
 
+    # capacity, cooldown
+    message_sent_cooldown: tuple[float, float] = (1, 60)
+
     mcoding_yt_id: str = "YOUTUBE_CHANNEL_ID"
     yt_api_key: str = "YOUTUBE_API_KEY"
 

--- a/mcodingbot/config.py
+++ b/mcodingbot/config.py
@@ -26,6 +26,7 @@ class Config:
 
     # capacity, cooldown
     message_sent_cooldown: tuple[float, float] = (1, 60)
+    highlight_trigger_cooldown: tuple[float, float] = (1, 30)
 
     mcoding_yt_id: str = "YOUTUBE_CHANNEL_ID"
     yt_api_key: str = "YOUTUBE_API_KEY"

--- a/mcodingbot/plugins/highlights.py
+++ b/mcodingbot/plugins/highlights.py
@@ -207,10 +207,7 @@ async def on_message(event: hikari.GuildMessageCreateEvent) -> None:
                 highlights[user_id].append(highlight)
 
     for user_id, hls in highlights.items():
-        if (
-            sent_message_cooldown.get_retry_after((user_id, event.channel_id))
-            != 0
-        ):
+        if sent_message_cooldown.get_retry_after((user_id, event.channel_id)):
             # the user has sent messages in this channel, so highlights are
             # not active for them in this channel.
             continue

--- a/mcodingbot/plugins/highlights.py
+++ b/mcodingbot/plugins/highlights.py
@@ -19,7 +19,7 @@ plugin = Plugin()
 highlights_group = crescent.Group("highlights")
 highlights_cache: dict[str, list[hikari.Snowflake]] = defaultdict(list)
 sent_message_cooldown: FixedCooldown[tuple[int, int]] = FixedCooldown(
-    *CONFIG.message_sent_cooldown
+    *CONFIG.highlight_message_sent_cooldown
 )
 trigger_cooldown: FixedCooldown[tuple[int, str]] = FixedCooldown(
     *CONFIG.highlight_trigger_cooldown

--- a/mcodingbot/plugins/highlights.py
+++ b/mcodingbot/plugins/highlights.py
@@ -17,7 +17,7 @@ MAX_HIGHLIGHTS = 25
 MAX_HIGHLIGHT_LENGTH = 32
 
 
-class MessageBucket(NamedTuple):
+class UserChannelBucket(NamedTuple):
     user: int
     channel: int
 
@@ -30,7 +30,7 @@ class TriggerBucket(NamedTuple):
 plugin = Plugin()
 highlights_group = crescent.Group("highlights")
 highlights_cache: dict[str, list[hikari.Snowflake]] = defaultdict(list)
-sent_message_cooldown: FixedCooldown[MessageBucket] = FixedCooldown(
+sent_message_cooldown: FixedCooldown[UserChannelBucket] = FixedCooldown(
     *CONFIG.highlight_message_sent_cooldown
 )
 trigger_cooldown: FixedCooldown[TriggerBucket] = FixedCooldown(
@@ -189,7 +189,7 @@ async def on_message(event: hikari.GuildMessageCreateEvent) -> None:
         return
 
     bucket = sent_message_cooldown.get_bucket(
-        MessageBucket(user=event.author_id, channel=event.channel_id)
+        UserChannelBucket(user=event.author_id, channel=event.channel_id)
     )
     # we need to reset the bucket, because calling update_ratelimit
     # only updates the limit if retry_after is none. Adding a `force`
@@ -220,7 +220,7 @@ async def on_message(event: hikari.GuildMessageCreateEvent) -> None:
 
     for user_id, hls in highlights.items():
         if sent_message_cooldown.get_retry_after(
-            MessageBucket(user=user_id, channel=event.channel_id)
+            UserChannelBucket(user=user_id, channel=event.channel_id)
         ):
             # the user has sent messages in this channel, so highlights are
             # not active for them in this channel.

--- a/mcodingbot/plugins/highlights.py
+++ b/mcodingbot/plugins/highlights.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import asyncio
 from collections import defaultdict
+from typing import NamedTuple
 
 import crescent
 import hikari
@@ -15,13 +16,24 @@ from mcodingbot.utils import Context, Plugin
 MAX_HIGHLIGHTS = 25
 MAX_HIGHLIGHT_LENGTH = 32
 
+
+class MessageBucket(NamedTuple):
+    user: int
+    channel: int
+
+
+class TriggerBucket(NamedTuple):
+    channel: int
+    highlight: str
+
+
 plugin = Plugin()
 highlights_group = crescent.Group("highlights")
 highlights_cache: dict[str, list[hikari.Snowflake]] = defaultdict(list)
-sent_message_cooldown: FixedCooldown[tuple[int, int]] = FixedCooldown(
+sent_message_cooldown: FixedCooldown[MessageBucket] = FixedCooldown(
     *CONFIG.highlight_message_sent_cooldown
 )
-trigger_cooldown: FixedCooldown[tuple[int, str]] = FixedCooldown(
+trigger_cooldown: FixedCooldown[TriggerBucket] = FixedCooldown(
     *CONFIG.highlight_trigger_cooldown
 )
 
@@ -177,7 +189,7 @@ async def on_message(event: hikari.GuildMessageCreateEvent) -> None:
         return
 
     bucket = sent_message_cooldown.get_bucket(
-        (event.author_id, event.channel_id)
+        MessageBucket(user=event.author_id, channel=event.channel_id)
     )
     # we need to reset the bucket, because calling update_ratelimit
     # only updates the limit if retry_after is none. Adding a `force`
@@ -194,7 +206,7 @@ async def on_message(event: hikari.GuildMessageCreateEvent) -> None:
     for highlight, users in highlights_cache.items():
         if highlight in event.content:
             retry_after = trigger_cooldown.update_ratelimit(
-                (event.channel_id, highlight)
+                TriggerBucket(channel=event.channel_id, highlight=highlight)
             )
             if retry_after:
                 # this highlight has been triggered in this channel too
@@ -207,7 +219,9 @@ async def on_message(event: hikari.GuildMessageCreateEvent) -> None:
                 highlights[user_id].append(highlight)
 
     for user_id, hls in highlights.items():
-        if sent_message_cooldown.get_retry_after((user_id, event.channel_id)):
+        if sent_message_cooldown.get_retry_after(
+            MessageBucket(user=user_id, channel=event.channel_id)
+        ):
             # the user has sent messages in this channel, so highlights are
             # not active for them in this channel.
             continue

--- a/mcodingbot/plugins/highlights.py
+++ b/mcodingbot/plugins/highlights.py
@@ -17,7 +17,7 @@ MAX_HIGHLIGHTS = 25
 MAX_HIGHLIGHT_LENGTH = 32
 
 
-class UserChannelBucket(NamedTuple):
+class SentMessageBucket(NamedTuple):
     user: int
     channel: int
 
@@ -30,7 +30,7 @@ class TriggerBucket(NamedTuple):
 plugin = Plugin()
 highlights_group = crescent.Group("highlights")
 highlights_cache: dict[str, list[hikari.Snowflake]] = defaultdict(list)
-sent_message_cooldown: FixedCooldown[UserChannelBucket] = FixedCooldown(
+sent_message_cooldown: FixedCooldown[SentMessageBucket] = FixedCooldown(
     *CONFIG.highlight_message_sent_cooldown
 )
 trigger_cooldown: FixedCooldown[TriggerBucket] = FixedCooldown(
@@ -189,7 +189,7 @@ async def on_message(event: hikari.GuildMessageCreateEvent) -> None:
         return
 
     bucket = sent_message_cooldown.get_bucket(
-        UserChannelBucket(user=event.author_id, channel=event.channel_id)
+        SentMessageBucket(user=event.author_id, channel=event.channel_id)
     )
     # we need to reset the bucket, because calling update_ratelimit
     # only updates the limit if retry_after is none. Adding a `force`
@@ -220,7 +220,7 @@ async def on_message(event: hikari.GuildMessageCreateEvent) -> None:
 
     for user_id, hls in highlights.items():
         if sent_message_cooldown.get_retry_after(
-            UserChannelBucket(user=user_id, channel=event.channel_id)
+            SentMessageBucket(user=user_id, channel=event.channel_id)
         ):
             # the user has sent messages in this channel, so highlights are
             # not active for them in this channel.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,7 @@ apgorm = "^1.0.0b12"
 rapidfuzz = "^2.10.0"
 cachetools = "^5.2.0"
 types-cachetools = "^5.2.1"
+pycooldown = "^0.1.0b9"
 
 [tool.poetry.dev-dependencies]
 nox = "^2022.8.7"


### PR DESCRIPTION
This makes a few changes to improve highlights
 - [x] If a message contains multiple triggers, combine them into a single DM.
 - [x] Have a cooldown of 30s per (highlight, user, channel)
 - [x] If a user sends a message in a channel, don't send them any highlights for the next minute.

These are just my feel for how it should work. If you think it should be tweaked lmk.