### PR TITLE
Made stats in thousands truncate to 1 decimal place

### DIFF
--- a/mcodingbot/plugins/stats.py
+++ b/mcodingbot/plugins/stats.py
@@ -143,7 +143,9 @@ def display_stats(stat: int | float) -> str:
         pretty_stat = stat / 1_000_000
         unit = "M"
 
-    pretty_stat = strip_trailing_zeros(truncate_decimals(pretty_stat, 2))
+    pretty_stat = strip_trailing_zeros(
+        truncate_decimals(pretty_stat, 1 if unit == "K" else 2)
+    )
     exp_stat = strip_trailing_zeros(truncate_decimals(log2(stat), 2))
     # ^ this might not be as accurate as the member count thing when
     # someone picky actually calculates it, but I suppose it's not


### PR DESCRIPTION
Numbers like `1357` were displayed as `1.35K`, which is a bruh moment because it's literally longer than just displaying the full number itself. So from now on it's gonna get truncated to just `1.3K`.