### PR TITLE
Use dependency groups and ignore ruff versions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,11 +1,8 @@
-# To get started with Dependabot version updates, you'll need to specify which
-# package ecosystems to update and where the package manifests are located.
-# Please see the documentation for all configuration options:
-# https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
-
 version: 2
 updates:
-  - package-ecosystem: "pip" # See documentation for possible values
-    directory: "/" # Location of package manifests
+  - package-ecosystem: "pip"
+    directory: "/"
     schedule:
       interval: "daily"
+    ignore:
+      - dependency-name: ruff

--- a/noxfile.py
+++ b/noxfile.py
@@ -10,6 +10,7 @@ def mypy(session: nox.Session) -> None:
 
 @nox.session(name="apply-lint")
 def apply_lint(session: nox.Session) -> None:
+    session.install("poetry")
     session.run("poetry", "install", "--only", "linting")
     session.run("black", ".")
     session.run("isort", ".")
@@ -18,6 +19,7 @@ def apply_lint(session: nox.Session) -> None:
 
 @nox.session
 def lint(session: nox.Session) -> None:
+    session.install("poetry")
     session.run("poetry", "install", "--only", "linting")
     session.run("black", ".", "--check")
     session.run("ruff", ".")

--- a/noxfile.py
+++ b/noxfile.py
@@ -4,7 +4,7 @@ import nox
 @nox.session
 def mypy(session: nox.Session) -> None:
     session.install("poetry")
-    session.run("poetry", "install", "--with", "typing")
+    session.run("poetry", "install")
     session.run("mypy", ".")
 
 

--- a/noxfile.py
+++ b/noxfile.py
@@ -4,16 +4,13 @@ import nox
 @nox.session
 def mypy(session: nox.Session) -> None:
     session.install("poetry")
-    session.run("poetry", "install")
-
+    session.run("poetry", "install", "--with", "typing")
     session.run("mypy", ".")
 
 
 @nox.session(name="apply-lint")
 def apply_lint(session: nox.Session) -> None:
-    session.install("black")
-    session.install("isort")
-    session.install("ruff")
+    session.run("poetry", "install", "--only", "linting")
     session.run("black", ".")
     session.run("isort", ".")
     session.run("ruff", ".", "--fix")
@@ -21,9 +18,7 @@ def apply_lint(session: nox.Session) -> None:
 
 @nox.session
 def lint(session: nox.Session) -> None:
-    session.install("black")
-    session.install("ruff")
-    session.install("isort")
+    session.run("poetry", "install", "--only", "linting")
     session.run("black", ".", "--check")
     session.run("ruff", ".")
     session.run("isort", ".", "--check")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,15 +15,19 @@ hikari-crescent = "^0.4.0"
 apgorm = "^1.0.0b12"
 rapidfuzz = "^2.10.0"
 cachetools = "^5.2.0"
-types-cachetools = "^5.2.1"
-pycooldown = "^0.1.0b9"
+floodgate-rs = "^0.1.1"
 
-[tool.poetry.dev-dependencies]
+[tool.poetry.group.dev.dependencies]
 nox = ">=2022.8.7"
+
+[tool.poetry.group.linting.dependencies]
 black = "^22.8.0"
 ruff = "^0.0.151"
 isort = "^5.10.1"
+
+[tool.poetry.group.typing.dependencies]
 mypy = "^0.991"
+types-cachetools = "^5.2.1"
 
 [tool.black]
 line-length = 79


### PR DESCRIPTION
This PR properly locks dependency versions in our CI