### PR TITLE
Add `no_db_mode` to config.json.example, fix unhandled when `no_db_mode` is true

### DIFF
--- a/config.json.example
+++ b/config.json.example
@@ -1,4 +1,5 @@
 {
-    "db_password": "DATABASE-PASSWORD",
-    "discord_token": "DISCORD-TOKEN"
+    "discord_token": "DISCORD-TOKEN",
+    "no_db_mode": true,
+    "db_password": "OPTIONAL-DATABASE-PASSWORD"
 }

--- a/mcodingbot/plugins/highlights.py
+++ b/mcodingbot/plugins/highlights.py
@@ -146,6 +146,9 @@ async def list_highlights(ctx: Context) -> None:
 @plugin.include
 @crescent.event
 async def on_start(_: hikari.StartingEvent) -> None:
+    if CONFIG.no_db_mode:
+        return
+
     highlights = await Highlight.fetchmany()
 
     for highlight, user_highlights in zip(


### PR DESCRIPTION
I guess this is a little out of scope of each other but i cba to make 2 separate PRs.

This is needed because `no_db_mode` being false by default adds an exception that kills the bot on launcher if a postgres database isn't running.