### PR TITLE
Enable new mypy error code possibly-undefined

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,6 +36,7 @@ warn_return_any = true
 warn_unused_configs = true
 strict = true
 namespace_packages = true
+enable_error_code = ["possibly-undefined"]
 
 [[tool.mypy.overrides]]
 module = 'asyncpg.*'


### PR DESCRIPTION
Still experimental, so it must be enabled explicitly. If it causes issues we can always disable later.